### PR TITLE
Clean temporary MMseqs2 files

### DIFF
--- a/plasx/mmseqs.py
+++ b/plasx/mmseqs.py
@@ -324,7 +324,7 @@ def createsubdb(subset,
                   'unintuitive. If you are unsure, look into the code for this function'.format(db_prefix))
         except:
             _, subset_file = tempfile.mkstemp()
-#            delete = True
+            delete = True
             with open(subset_file, 'wt') as f:
                 f.write('\n'.join(map(str, subset)) + '\n')
         
@@ -334,21 +334,14 @@ def createsubdb(subset,
         output_fa = str(output_prefix) + '_fa'
 
         cmd = ' '.join([mmseqs_cmd, 'createsubdb', subset_file, db_prefix, output])
-        print(cmd)
-        utils.run_cmd(cmd, shell=True, tee=True)
-#        subprocess.run(cmd, shell=True, check=True)
-
+        utils.run_cmd(cmd, shell=True, tee=True, verbose=True)
 
         cmd = ' '.join([mmseqs_cmd, 'createsubdb', subset_file, db_prefix + '_h', output_h])
-        print(cmd)
-        utils.run_cmd(cmd, shell=True, tee=True)
-#        subprocess.run(cmd, shell=True, check=True)
+        utils.run_cmd(cmd, shell=True, tee=True, verbose=True)
 
         if convert2fasta:
             cmd = ' '.join([mmseqs_cmd, 'convert2fasta', output, output_fa])
-            print(cmd)
-            utils.run_cmd(cmd, shell=True, tee=True)
-#            subprocess.run(cmd, shell=True, check=True)
+            utils.run_cmd(cmd, shell=True, tee=True, verbose=True)
 
     finally:
         if delete:
@@ -478,6 +471,7 @@ def prep_mmseqs_fasta(input_fa, output_prefix, header_filter=None):
 
     """
     output_prefix = str(output_prefix)
+
 
     if input_fa is not None:        
         df = utils.index_fasta_headers(input_fa,
@@ -941,6 +935,8 @@ def get_unique_sequences(db,
         threads = utils.get_max_threads()
 
     with tempfile.TemporaryDirectory() as tempdir:
+        print('Temp unique_sequences:', tempdir)
+
         clusthash = os.path.join(tempdir, 'clusthash')
         clu = os.path.join(tempdir, 'clu')
         if table_output is None:
@@ -1654,7 +1650,7 @@ def mmseqs_search(source_db, target_db, output,
                   threads=None,
                   splits=None,
                   sleep_seconds=300,
-                  clean_mmseqs_tmp=True):
+                  clean_tmp=None):
     """
     Do sequence-to-sequence search with mmseqs
     """
@@ -1684,20 +1680,22 @@ def mmseqs_search(source_db, target_db, output,
         utils.tprint(f'Sleeping for {sleep_seconds} seconds to let the file system flush')
         time.sleep(sleep_seconds) # Sleep, to let files from command freshen up
 
+        names = ['qId', 'tId',
+                 'seqIdentity', 'alnLen', 'mismatchCnt', 'gapOpenCnt',
+                 'qStart', 'qEnd', 'qlen', 'tStart', 'tEnd', 'tlen', 'eVal', 'bitScore']
+        _ = pickle_alignm8(output + '.m8', low_memory=True, names=names)
+
     finally:
-        # Remove temporary subdirectory created by mmseqs
-        if clean_mmseqs_tmp:
+        # Remove temporary files created by mmseqs. Only the *.m8.pkl.blp file is kept.
+        if clean_tmp:
             if os.path.exists(f'{output}.search.tmp'):
                 shutil.rmtree(f'{output}.search.tmp')
+            if os.path.exists(f'{output}.m8'):
+                os.remove(f'{output}.m8')
             for file in glob.glob(f'{output}.search*'):
-                os.path.remove(file)
+                os.remove(file)
 
-    names = ['qId', 'tId',
-             'seqIdentity', 'alnLen', 'mismatchCnt', 'gapOpenCnt',
-             'qStart', 'qEnd', 'qlen', 'tStart', 'tEnd', 'tlen', 'eVal', 'bitScore']
-    _ = pickle_alignm8(output + '.m8', low_memory=True, names=names)
-
-def mmseqs_merge_search(source_db, target_db_dir, output, ident_list, threads=None, splits=None):
+def mmseqs_merge_search(source_db, target_db_dir, output, ident_list, threads=None, splits=None, clean_tmp=None):
     """Runs mmseqs_search on multiple sets of clusters, where each set was created at a different identity"""
 
     target_db_pattern = os.path.join(target_db_dir, 'clu{identity}.profile')
@@ -1717,7 +1715,8 @@ def mmseqs_merge_search(source_db, target_db_dir, output, ident_list, threads=No
                           output_pattern.format(identity=identity),
                           threads=threads,
                           splits=splits,
-                          sleep_seconds=5)
+                          sleep_seconds=5,
+                          clean_tmp=clean_tmp)
         else:
             utils.tprint(f"################ SKIPPING Identity {identity} (file doesn't exist probably it had no clusters after merging clusters ######################")
 
@@ -1890,8 +1889,16 @@ def download_pretrained_plasx_model(ver=None, data_dir=None, mmseqs_profiles_url
             f.extractall(out_path)
 
 
-def annotate_de_novo_families(gene_calls, target_db=None, output_dir=None, ident_list=None, 
-                              threads=None, splits=None, output=None, output_kws=None, overwrite=None):
+def annotate_de_novo_families(gene_calls,
+                              target_db=None,
+                              output_dir=None,
+                              ident_list=None, 
+                              threads=None,
+                              splits=None,
+                              output=None,
+                              output_kws=None,
+                              overwrite=None,
+                              clean_tmp=None):
     """Takes in a table of amino acid sequences and searches them against
     a target mmseqs database of gene clusters
 
@@ -1917,7 +1924,7 @@ def annotate_de_novo_families(gene_calls, target_db=None, output_dir=None, ident
     target_db_dir = get_target_db(target_db) 
 
     # Create temporary directory, if one is not specified
-    with utils.TemporaryDirectory(name=output_dir, verbose=True, overwrite=overwrite) as output_dir:
+    with utils.TemporaryDirectory(name=output_dir, verbose=True, overwrite=overwrite, post_delete=clean_tmp) as output_dir:
 
         # Setup output paths
         mmseqs_dir = output_dir / 'mmseqs'
@@ -1932,8 +1939,10 @@ def annotate_de_novo_families(gene_calls, target_db=None, output_dir=None, ident
         # Create mmseqs database from fasta file
         create_mmseqs_db(gene_calls_out, mmseqs_source_db)
 
+#        0 / asdf
+
         # Search sequences against target databases of gene clusters
-        mmseqs_merge_search(mmseqs_source_db, target_db_dir, mmseqs_dir, ident_list, threads=threads, splits=splits)
+        mmseqs_merge_search(mmseqs_source_db, target_db_dir, mmseqs_dir, ident_list, threads=threads, splits=splits, clean_tmp=clean_tmp)
 
         # Process search - retain only hits with >80% query AND target coverage, and with sufficient identity
         hits = process_mmseqs_merge_search(mmseqs_source_db, target_db_dir, mmseqs_dir, ident_list,

--- a/plasx/plasx_script.py
+++ b/plasx/plasx_script.py
@@ -42,9 +42,11 @@ def search(args):
                               overwrite= 2 if args.overwrite else 1,
                               output_kws=dict(txt=True),
                               threads=args.threads,
-                              splits=args.splits)
+                              splits=args.splits,
+                              clean_tmp=not args.save_tmp)
 
 def fit(args):
+    raise Exception("Not Implemented")
     print(args)
 
 def get_parser():   
@@ -78,7 +80,7 @@ have scores closer to 0.""")
     fit_parser.set_defaults(func=fit)
 
     ## Search parser
-    search_parser = subparsers.add_parser('search_de_novo_families', help='Annotates genes to de novo families. Uses mmseqs2 for fast sequence alignment.')
+    search_parser = subparsers.add_parser('search_de_novo_families', help='Annotates genes to de novo families. Uses MMseqs2 for fast sequence alignment.')
     search_parser.set_defaults(func=search)
     required = search_parser.add_argument_group('required arguments')
     optional = search_parser.add_argument_group('optional arguments')
@@ -90,16 +92,19 @@ have scores closer to 0.""")
         help="""File to save predictions""")
     optional.add_argument(
         '-db', dest='target_db', default=None,
-        help="""Location of precomputed mmseqs2 profiles. You only need to specify this if you downloaded the PlasX model to a custom location using the '-o' flag in `plasx setup`. Default: PlasX will search the default download location in its installation diretory.""")
+        help="""Location of precomputed MMseqs2 profiles. You only need to specify this if you downloaded the PlasX model to a custom location using the '-o' flag in `plasx setup`. Default: PlasX will search the default download location in its installation diretory.""")
     optional.add_argument(
         '-T', '--threads', dest='threads', type=int, default=None,
-        help="""Number of threads to run mmseqs2 with. Default: The number of CPUs available on this machine.""")
+        help="""Number of threads to run MMseqs2 with. Default: The number of CPUs available on this machine.""")
     optional.add_argument(
         '-S', '--splits', dest='splits', type=int, default=1,
-        help="""This will split PlasX's set of de novo families into an equal number of chunks for searching, reducing the maximum RAM usage. Searching will fail if your machine has insufficient RAM, so you should consider increasing the number of splits. If you have only ~8Gb of RAM, then we recommend settings -S to 32. Setting -S to 0 will let mmseqs2 decide the number of splits automatically. Default: 1 split.""")
+        help="""This will split PlasX's set of de novo families into an equal number of chunks for searching, reducing the maximum RAM usage. Searching will fail if your machine has insufficient RAM, so you should consider increasing the number of splits. If you have only ~8Gb of RAM, then we recommend settings -S to 32. Setting -S to 0 will let MMseqs2 decide the number of splits automatically. Default: 1 split.""")
     optional.add_argument(
         '--tmp', dest='tmp', default=None,
-        help="""Directory to save intermediate files, including ones created by mmseqs2. Default: a temporary directory that is deleted upon termination""")
+        help="""Directory to save temporary intermediate files, including ones created by MMseqs2. This directory is deleted upon termination, unless '--save-tmp' is specified. Default: a directory with a random name is created (e.g. inside /tmp)""")
+    optional.add_argument(
+        '--save-tmp', dest='save_tmp', action='store_true',
+        help="""Do NOT delete the directory of intermediate files upon termination. Note: these files use a lot of disk storage, so only keep them if needed for debugging.""")
     optional.add_argument(
         '--overwrite', dest='overwrite', action='store_true', default=False,
         help="""Overwrite files""")

--- a/plasx/utils.py
+++ b/plasx/utils.py
@@ -401,30 +401,43 @@ def TemporaryDirectory(name=None, post_delete=None, path=True, verbose=False,
     string)
 
     overwrite : If False, then check if file already exists, and raise Exception if so. Default: True.
-
-    pre_delete : If True, then first delete the directory if it already exists. Default: False
+  
+    post_delete : If True, then delete the directory upon exiting this context. If False, don't delete. If not specified, then set to True if `name` is None, otherwise False.
     """
 
     try:
         if name is None:
-            delete = True
+            if post_delete is None:
+                post_delete = True
             name = tempfile.mkdtemp()
             if verbose:
                 print('Created temporary directory:', name)
         else:
             check_overwrite(name, overwrite, overwrite_err_msg)
-            
             os.makedirs(name, exist_ok=True)
-            delete = False
-            
+            if post_delete is None:
+                post_delete = False
+
+        if verbose:
+            print('Using temporary directory:', name, end='')
+            if post_delete:
+                print(' (This will be deleted after execution)')
+            else:
+                print(' (This will NOT be deleted after execution)')
+                
         if path:
             name = Path(name)
 
         yield name
 
     finally:
-        if (post_delete is True or delete) and (name is not None):
+        if post_delete:
+            if verbose:
+                print('Deleting temporary directory:', name)
             shutil.rmtree(name)
+        else:
+            if verbose:
+                print(f'Temporary directory {name} was NOT deleted.')
 
 def check_overwrite(path, overwrite=None, overwrite_err_msg=None):
     """


### PR DESCRIPTION
fixes #1 

After searching the MMseqs2 clusters of a specific alignment identity, clean up the temporary files before proceeding to search the clusters at the next identity.